### PR TITLE
fix: Docker build and runtime issues with Next.js 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ npm run dev
 
 ## Troubleshooting
 
-- **Ports**: Ensure ports 5005 and 5006 are free.
+- **Ports**: Ensure ports 5005 and 3100 are free.
+- **Database Error**: If you see `SQLITE_CANTOPEN`, ensure `dev.db` is a file, not a directory. Run `rm -rf dev.db && touch dev.db` before starting Docker.
 - **Permissions**: You must allow camera/microphone access in your browser when prompted.
 - **Video Export**: Exporting uses FFmpeg. Ensure your system can run the static binaries provided by `ffmpeg-static`.
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This is the easiest way to get up and running locally.
 1.  **Prerequisites**: Ensure Docker and Docker Compose are installed.
 2.  **Start Services**:
     ```bash
+    mkdir -p recordings uploads && touch dev.db
     docker compose up --build
     ```
 3.  **Access App**: Open `http://localhost:3100` in your browser.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       args:
         BACKEND_URL: http://backend:5005
     ports:
-      - "3100:3000"
+      - "3100:3101"
     environment:
       - BACKEND_URL=http://backend:5005
       - NEXT_PUBLIC_BACKEND_URL=http://localhost:5005 # For client-side direct uploads

--- a/frontend/src/app/record/page.tsx
+++ b/frontend/src/app/record/page.tsx
@@ -1,5 +1,10 @@
+import { Suspense } from 'react';
 import Recorder from '@/components/Recorder';
 
 export default function RecordPage() {
-    return <Recorder />;
+    return (
+        <Suspense fallback={<div>Loading...</div>}>
+            <Recorder />
+        </Suspense>
+    );
 }


### PR DESCRIPTION
- Wrap Recorder component in Suspense boundary for useSearchParams() compatibility
- Fix Docker port mapping (3100:3101) to match actual Next.js port
- Update README with troubleshooting for SQLITE_CANTOPEN error